### PR TITLE
Gilneas Teleport Toy

### DIFF
--- a/Spells.lua
+++ b/Spells.lua
@@ -10,6 +10,7 @@ local MapIDAlterac = 943
 local MapIDMaw = 1543
 local MapIDKorthia = 1961
 local MapIDMechagon = 1462
+local MapIDGilneas = 202
 
 local ContinentIdOutland = 101
 local ContinentIdPandaria = 424
@@ -503,6 +504,12 @@ CreateDestination(
 		CreateItem(110560),				-- Garrison Hearthstone
 	})
 
+CreateDestination(
+	LocZone("Gilneas", 202),
+	{
+		CreateItem(211788),	-- Gilneas City
+	})
+	
 	
 CreateDestination(
 	LocZone("Hall of the Guardian", 734),

--- a/Spells.lua
+++ b/Spells.lua
@@ -503,6 +503,11 @@ CreateDestination(
 		CreateItem(110560),				-- Garrison Hearthstone
 	})
 
+CreateDestination(
+	LocZone("Gilneas", 202),
+	{
+		CreateItem(211788),	-- Gilneas City
+	})
 	
 CreateDestination(
 	LocZone("Hall of the Guardian", 734),

--- a/Spells.lua
+++ b/Spells.lua
@@ -10,6 +10,7 @@ local MapIDAlterac = 943
 local MapIDMaw = 1543
 local MapIDKorthia = 1961
 local MapIDMechagon = 1462
+local MapIDGilneas = 202
 
 local ContinentIdOutland = 101
 local ContinentIdPandaria = 424

--- a/Spells.lua
+++ b/Spells.lua
@@ -62,6 +62,13 @@ local function IsClass(requiredClass)
 	end
 end
 
+local function IsRace(requiredRace)
+	return function()
+		local _, playerRace = UnitRace("player")
+		return playerRace == requiredRace
+	end
+end
+
 local function HaveUpgradedZen()
 	return C_QuestLog.IsQuestFlaggedCompleted(40236)
 end
@@ -507,7 +514,7 @@ CreateDestination(
 CreateDestination(
 	LocZone("Gilneas", 202),
 	{
-		CreateConditionalItem(211788, IsRace("WORGEN")),	-- Gilneas City
+		CreateConditionalItem(211788, IsRace("Worgen")),	-- Gilneas City
 	})
 	
 CreateDestination(

--- a/Spells.lua
+++ b/Spells.lua
@@ -507,7 +507,7 @@ CreateDestination(
 CreateDestination(
 	LocZone("Gilneas", 202),
 	{
-		CreateItem(211788),	-- Gilneas City
+		CreateConditionalItem(211788, IsRace("WORGEN")),	-- Gilneas City
 	})
 	
 CreateDestination(

--- a/Spells.lua
+++ b/Spells.lua
@@ -10,7 +10,6 @@ local MapIDAlterac = 943
 local MapIDMaw = 1543
 local MapIDKorthia = 1961
 local MapIDMechagon = 1462
-local MapIDGilneas = 202
 
 local ContinentIdOutland = 101
 local ContinentIdPandaria = 424
@@ -504,12 +503,6 @@ CreateDestination(
 		CreateItem(110560),				-- Garrison Hearthstone
 	})
 
-CreateDestination(
-	LocZone("Gilneas", 202),
-	{
-		CreateItem(211788),	-- Gilneas City
-	})
-	
 	
 CreateDestination(
 	LocZone("Hall of the Guardian", 734),


### PR DESCRIPTION
Added "[Tess's Peacebloom](https://www.wowhead.com/item=211788/tesss-peacebloom)" to teleport to Gilneas which is obtained from the Quest chain. Also added Race Restriction, as this only works for Worgen.