### PR TITLE
removed covenant condition

### DIFF
--- a/Spells.lua
+++ b/Spells.lua
@@ -194,10 +194,10 @@ CreateDestination(
 		-- I don't know how to check if a covenant hearthstone can be used. To work
 		-- around this, only make them available for other covenants when not using
 		-- the random hearthstone option.
-		CreateConditionalItem(180290, TeleporterCanUseCovenantHearthstone(3)),	-- Night Fae Hearthstone
-		CreateConditionalItem(182773, TeleporterCanUseCovenantHearthstone(4)),	-- Necrolord Hearthstone
-		CreateConditionalItem(183716, TeleporterCanUseCovenantHearthstone(2)),	-- Venthyr Sinstone
-		CreateConditionalItem(184353, TeleporterCanUseCovenantHearthstone(1)),	-- Kyrian Hearthstone
+		CreateItem(180290),				-- Night Fae Hearthstone
+		CreateItem(182773),				-- Necrolord Hearthstone
+		CreateItem(183716),				-- Venthyr Sinstone
+		CreateItem(184353),				-- Kyrian Hearthstone
 		CreateItem(188952),				-- Dominated Hearthstone
 		CreateItem(190196),				-- Enlightened Hearthstone
 		CreateItem(190237),				-- Broker Translocation Matrix

--- a/TomeOfTeleportation.lua
+++ b/TomeOfTeleportation.lua
@@ -2292,12 +2292,6 @@ function TeleporterIsUnsupportedItem(spell)
 	return false
 end
 
-function TeleporterCanUseCovenantHearthstone(covenant)
-	return function()
-		return (C_Covenants and C_Covenants.GetActiveCovenantID() == covenant) or not GetOption("randomHearth")
-	end
-end
-
 
 --------
 -- Functions used by tests


### PR DESCRIPTION
Covenant Hearthstones are no longer limited to membership of a covenant. Removed the Condition so they are all listed unter Hearthstones and also appead during Random HS.

Testing with a Level 60 Evoker who never set foot in Shadowlands Terretory.