### PR TITLE
[F] Cypher of Relocation - zone bug

### DIFF
--- a/Spells.lua
+++ b/Spells.lua
@@ -839,7 +839,7 @@ CreateDestination(
 CreateDestination(
 	LocZone("The Maw", 1543),
 	{
-		CreateConditionalConsumable(180817, function() return AtZone(MapIDMaw)() and not AtZone(MapIDKorthia)() end),	-- Cypher of Relocation
+		CreateConditionalConsumable(180817, function() return TeleporterGetOption("showInWrongZone") or (AtZone(MapIDMaw)() and not AtZone(MapIDKorthia)()) end),	-- Cypher of Relocation
 	})
 	
 CreateDestination(


### PR DESCRIPTION
if ```TeleporterGetOption("showInWrongZone")``` is true. the ```AtZone``` function always return true:
```
local function AtZone(requiredZone)
	return function()
		if TeleporterGetOption("showInWrongZone") then
			return true
		end
		local mapID = C_Map.GetBestMapForUnit("player")
		while mapID ~= 0 do
			if mapID == requiredZone then
				return true
			end
			mapID = C_Map.GetMapInfo(mapID).parentMapID
		end
		return false
	end
end
```

then the ```function() return AtZone(MapIDMaw)() and not AtZone(MapIDKorthia)()) end``` for Cypher of Relocation will be false. which is not expected when ```TeleporterGetOption("showInWrongZone")``` option is true.

in this special case, we can just add an additional ```TeleporterGetOption("showInWrongZone") or ``` before the AtZone function called.

in the future, if there are more case like the "Maw with Korthia", you should abstract a comprehensive function to avoid this issue.

---

btw, whats IDE are you using, if it's vscode, try to open this in setting, to avoid white space:
![3981714209510_ pic](https://github.com/davidmeen/TomeOfTeleportation/assets/8273263/6bc0ada5-c060-4853-a61c-2f5f64d8e314)
![WeChatb92d957c198ae058c8ea1c9628c8f75d](https://github.com/davidmeen/TomeOfTeleportation/assets/8273263/56b4afff-5422-4871-ac35-08f5608ecf6c)


 
