### PR TITLE
[U] concise dungeon spells - from prefix to other suffix language

### DIFF
--- a/TeleporterSpell.lua
+++ b/TeleporterSpell.lua
@@ -5,7 +5,7 @@ local ST_Challenge = 3
 
 -- I'm not going to attempt any prefixes with different character sets. I may have missed some variations.
 -- Some of these are odd - inconsistent translations in-game?
-local HiddenPrefixes = 
+local RedundantStrings =
 {
 	-- German
 	"Pfad der ",
@@ -34,6 +34,14 @@ local HiddenPrefixes =
 	"Caminho da ",
 	"Caminho do ",
 	"Caminho dos ",
+	-- Simplified Chinese
+	"之路",
+	-- Traditional Chinese
+	"之路",
+	"之道",
+	"之徑",
+	-- Korean
+	" 길",
 }
 
 local TeleporterSpell = {}
@@ -51,14 +59,11 @@ function TeleporterSpell:IsDungeonSpell()
 end
 
 function TeleporterSpell:CleanupName()
-	local hide = TeleporterGetOption("hidePrefixes")
+	local hide = TeleporterGetOption("conciseDungeonSpells")
     local name = self.spellName
 	if (hide == 1 or hide == "1") and self:IsDungeonSpell() then
-		for index, prefix in pairs(HiddenPrefixes) do
-			local foundIndex = strfind(name, prefix)
-			if foundIndex == 1 then
-				name = strsub(name, strlen(prefix))
-			end
+		for index, str in pairs(RedundantStrings) do
+			name = name: gsub(str, "")
 		end
 	end
 	return name

--- a/TomeOfTeleportation.lua
+++ b/TomeOfTeleportation.lua
@@ -125,7 +125,7 @@ local DefaultOptions =
 	["sortDownIcon"] = "Interface/Icons/misc_arrowdown",
 	["showButtonIcon"] = "Interface/Icons/levelupicon-lfd",
 	["removeButtonIcon"] = "Interface/Icons/INV_Misc_Bone_Skull_03",
-	["hidePrefixes"] = 1
+	["conciseDungeonSpells"] = 1
 }
 
 -- Themes. For now there aren't many of these. Message me on curseforge.com

--- a/TomeOfTeleportationSettings.lua
+++ b/TomeOfTeleportationSettings.lua
@@ -257,7 +257,7 @@ local function CreateSettings(panel)
     p = AddCheckOption("Show Spells Everywhere",    "showInWrongZone",      scrollChild, p)
     p = AddCheckOption("Close After Cast",          "closeAfterCast",       scrollChild, p)
     p = AddCheckOption("Show Title",                "showTitle",            scrollChild, p)
-    p = AddCheckOption("Hide Spell Prefixes",       "hidePrefixes",         scrollChild, p)
+    p = AddCheckOption("Concise Dungeon Spells",    "conciseDungeonSpells", scrollChild, p)
     p = AddCheckOption("Use Old Customizer",        "oldCustomizer",        scrollChild, p)
 
     p = AddSliderOption("Button Width",         "buttonWidth", 20, 400, 1,              scrollChild, p)


### PR DESCRIPTION
some eastern language such as Simplified Chinese / Traditional Chinese / Korean is not use prefix as "Path of the".

and I think its ok to just gsub the string from name, blizzard won't put more than one "Path of the" sub string in a spell name.