### PR TITLE
Add Druid Flight Form Cancellation

### DIFF
--- a/TomeOfTeleportation.lua
+++ b/TomeOfTeleportation.lua
@@ -1014,12 +1014,6 @@ function TeleporterUpdateButton(button)
 			end
 			button.backdrop:SetBackdropColor(GetOption("disabledColourR"), GetOption("disabledColourG"), GetOption("disabledColourB"), alpha)
 			button:SetAttribute("macrotext", nil)
-		elseif isFlyingDruid then
-			button.backdrop:SetBackdropColor(GetOption("druidFormColourR"), GetOption("druidFormColourG"), GetOption("druidFormColourB"), 1)
-
-			button:SetAttribute(
-				"macrotext",
-				"/cancelform")
 		elseif isItem and TeleporterItemMustBeEquipped( item ) then
 			button.backdrop:SetBackdropColor(GetOption("unequipedColourR"), GetOption("unequipedColourG"), GetOption("unequipedColourB"), 1)
 
@@ -1029,12 +1023,20 @@ function TeleporterUpdateButton(button)
 		elseif onCooldown then
 			if cooldownDuration >2 then
 				button.backdrop:SetBackdropColor(GetOption("cooldownColourR"), GetOption("cooldownColourG"), GetOption("cooldownColourB"), 1)
+			elseif isFlyingDruid then
+				button.backdrop:SetBackdropColor(GetOption("druidFormColourR"), GetOption("druidFormColourG"), GetOption("druidFormColourB"), 1)
 			else
 				button.backdrop:SetBackdropColor(GetOption("readyColourR"), GetOption("readyColourG"), GetOption("readyColourB"), 1)
 			end
 			button:SetAttribute(
 				"macrotext",
 				"/script print( \"" .. item .. " is currently on cooldown.\")")
+		elseif isFlyingDruid then
+			button.backdrop:SetBackdropColor(GetOption("druidFormColourR"), GetOption("druidFormColourG"), GetOption("druidFormColourB"), 1)
+
+			button:SetAttribute(
+				"macrotext",
+				"/cancelform")
 		else
 			button.backdrop:SetBackdropColor(GetOption("readyColourR"), GetOption("readyColourG"), GetOption("readyColourB"), 1)
 

--- a/TomeOfTeleportation.lua
+++ b/TomeOfTeleportation.lua
@@ -117,6 +117,9 @@ local DefaultOptions =
 	["unequipedColourR"] = 1,
 	["unequipedColourG"] = 0,
 	["unequipedColourB"] = 0,
+	["druidFormColourR"] = 1,
+	["druidFormColourG"] = 0.49,
+	["druidFormColourB"] = 0.04,
 	["cooldownColourR"] = 1,
 	["cooldownColourG"] = 0.7,
 	["cooldownColourB"] = 0,
@@ -945,6 +948,8 @@ function TeleporterUpdateButton(button)
 	local onCooldown = false
 	local buttonInset = GetScaledOption("buttonInset")
 
+	local _, isFlyingDruid, _, _ = GetShapeshiftFormInfo(3)
+
 	if item then
 		local cooldownStart, cooldownDuration
 		if isItem then
@@ -1009,6 +1014,12 @@ function TeleporterUpdateButton(button)
 			end
 			button.backdrop:SetBackdropColor(GetOption("disabledColourR"), GetOption("disabledColourG"), GetOption("disabledColourB"), alpha)
 			button:SetAttribute("macrotext", nil)
+		elseif isFlyingDruid then
+			button.backdrop:SetBackdropColor(GetOption("druidFormColourR"), GetOption("druidFormColourG"), GetOption("druidFormColourB"), 1)
+
+			button:SetAttribute(
+				"macrotext",
+				"/cancelform")
 		elseif isItem and TeleporterItemMustBeEquipped( item ) then
 			button.backdrop:SetBackdropColor(GetOption("unequipedColourR"), GetOption("unequipedColourG"), GetOption("unequipedColourB"), 1)
 

--- a/TomeOfTeleportation.lua
+++ b/TomeOfTeleportation.lua
@@ -948,7 +948,12 @@ function TeleporterUpdateButton(button)
 	local onCooldown = false
 	local buttonInset = GetScaledOption("buttonInset")
 
-	local _, isFlyingDruid, _, _ = GetShapeshiftFormInfo(3)
+	-- Detect druid flight form - only check if player is a druid
+	local isFlyingDruid = false;
+	local _, playerClass = UnitClass("player");
+	if playerClass == "DRUID" then
+		_, isFlyingDruid, _, _ = GetShapeshiftFormInfo(3);
+	end
 
 	if item then
 		local cooldownStart, cooldownDuration

--- a/TomeOfTeleportationSettings.lua
+++ b/TomeOfTeleportationSettings.lua
@@ -325,6 +325,8 @@ local function CreateSettings(panel)
     p = AddColourOption("Unequiped Colour",     "unequipedColour",                      scrollChild, false, p)
     p = AddColourOption("Cooldown Colour",      "cooldownColour",                       scrollChild, false, p)
     p = AddColourOption("Disabled Colour",      "disabledColour",                       scrollChild, false, p)
+    p = AddColourOption("Druid Form Colour",    "druidFormColour",                      scrollChild, false, p)
+
 
     p = AddSliderOption("Quick Menu Size",      "QuickMenuSize", 20, 100, 1,             scrollChild, p)
 end


### PR DESCRIPTION
Currently, when a druid is in Travel/Flight Form on the ground, trying to use a teleport will result in "Can't use that ability while pacified.". It will also still trigger window closure if that is enabled.

This change:
- Detects flight form state
- Sets all otherwise enabled buttons to the druid form color (default is druid class color 1.00/0.49/0.04) if in flight form
- Makes the button cancel flight form, which also doesn't trigger window closure
- Adds customization of the druid form color

Downsides:
- It will dismount you if you are flying high up.
- Technically adds a GCD to non-flying travel form (for example, areas where you can't fly, like Siren Isle pre-ring-upgrade, Molten Front, etc.)
- There may be other pacification cases that could be detected, but they would require separate cancellation techniques.